### PR TITLE
fix IllegalAddException in OAIUtils.jdomToDOM()

### DIFF
--- a/oaipmh/src/main/java/org/mycore/oai/pmh/OAIUtils.java
+++ b/oaipmh/src/main/java/org/mycore/oai/pmh/OAIUtils.java
@@ -1,6 +1,5 @@
 package org.mycore.oai.pmh;
 
-import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.JDOMException;
 import org.jdom2.input.DOMBuilder;
@@ -52,8 +51,8 @@ public abstract class OAIUtils {
      */
     public static org.w3c.dom.Element jdomToDOM(Element jdomElement) throws JDOMException {
         DOMOutputter outputter = new DOMOutputter();
-        org.w3c.dom.Document doc = outputter.output(new Document(jdomElement));
-        return doc.getDocumentElement();
+        org.w3c.dom.Element element = outputter.output(jdomElement);
+        return element;
     }
 
     /**

--- a/oaipmh/src/test/java/org/mycore/oai/pmh/OAIUtilsTest.java
+++ b/oaipmh/src/test/java/org/mycore/oai/pmh/OAIUtilsTest.java
@@ -1,0 +1,26 @@
+package org.mycore.oai.pmh;
+
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.JDOMException;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class OAIUtilsTest {
+
+    @Test
+    public void jdomToDOM_withDoc() throws JDOMException {
+        Document doc=new Document(new Element("junit"));
+        final org.w3c.dom.Element domElement = OAIUtils.jdomToDOM(doc.getRootElement());
+        assertEquals(doc.getRootElement().getName(), domElement.getNodeName());
+        assertTrue(domElement.getOwnerDocument() != null);
+    }
+    @Test
+    public void jdomToDOM_withoutDoc() throws JDOMException {
+        final Element jdomElement = new Element("junit");
+        final org.w3c.dom.Element domElement = OAIUtils.jdomToDOM(jdomElement);
+        assertEquals(jdomElement.getName(), domElement.getNodeName());
+        assertTrue(domElement.getOwnerDocument() != null);
+    }
+}


### PR DESCRIPTION
jdom elements may already be linked to a document node
fixes #27